### PR TITLE
bump html-webpack-inline-source-plugin to 1.0.0-beta.2 to fix build i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@types/react-dom": "^16.9.6",
 		"@types/react": "^16.9.32",
 		"css-loader": "^3.5.1",
-		"html-webpack-inline-source-plugin": "^0.0.10",
+		"html-webpack-inline-source-plugin": "^1.0.0-beta.2",
 		"html-webpack-plugin": "^4.0.4",
 		"husky": "^4.2.3",
 		"lint-staged": "^10.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,6 @@ module.exports = (env, argv) => ({
       inlineSource: '.(js)$',
       chunks: ['ui'],
     }),
-    new HtmlWebpackInlineSourcePlugin(),
+    new HtmlWebpackInlineSourcePlugin(HtmlWebpackPlugin),
   ],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,10 +2359,10 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
-html-webpack-inline-source-plugin@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/html-webpack-inline-source-plugin/-/html-webpack-inline-source-plugin-0.0.10.tgz#89bd5f761e4f16902aa76a44476eb52831c9f7f0"
-  integrity sha512-0ZNU57u7283vrXSF5a4VDnVOMWiSwypKIp1z/XfXWoVHLA1r3Xmyxx5+Lz+mnthz/UvxL1OAf41w5UIF68Jngw==
+html-webpack-inline-source-plugin@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/html-webpack-inline-source-plugin/-/html-webpack-inline-source-plugin-1.0.0-beta.2.tgz#71a9234c170ef18df6e51f4594a09b540ff03111"
+  integrity sha512-ydsEKdp0tnbmnqRAH2WSSMXerCNYhjes5b79uvP2BU3p6cyk+6ucNMsw5b5xD1QxphgvBBA3QqVmdcpu8QLlRQ==
   dependencies:
     escape-string-regexp "^1.0.5"
     slash "^1.0.0"


### PR DESCRIPTION
Even though the [html-webpack-inline-source-plugin](https://github.com/DustinJackson/html-webpack-inline-source-plugin) has just recently been deprecated in favor of the [plugin that Facebook provides](https://github.com/facebook/create-react-app/blob/edc671eeea6b7d26ac3f1eb2050e50f75cf9ad5d/packages/react-dev-utils/InlineChunkHtmlPlugin.js#L10), this lil tweak gets the plugin building again and working as expected for the time being. LMK if you run into any bugs or issues with it, but this gets everything working again for me! 